### PR TITLE
Fix problem where axis with no mappings was erroring out during roundtrip

### DIFF
--- a/Lib/glyphsLib/builder/builders.py
+++ b/Lib/glyphsLib/builder/builders.py
@@ -749,6 +749,19 @@ class GlyphsBuilder(_LoggerMixin):
                         )
                     )
                     setattr(source, name, getattr(source.font.info, name))
+        # An axis without a mapping will see its range information (min and max
+        # values) lost when converted to a Glyps.app file. To combat this we
+        # add an explicit identity mapping.
+        for axis in copy.axes:
+            if axis.map:
+                continue
+            if axis.minimum == axis.maximum:
+                axis.map = [(axis.minimum, axis.minimum)]
+            else:
+                axis.map = [
+                    (axis.minimum, axis.minimum),
+                    (axis.maximum, axis.maximum),
+                ]
         return copy
 
     def _fake_designspace(self, ufos):


### PR DESCRIPTION
Problem: during `to_designspace` execution in the `to_glyphs`, `to_designspace` roundtrip, an error occurs when a custom axis contains no mappings.

`ValueError: min() arg is an empty sequence`

This occurs because Glyphs.app does not store an axis' `minimum`, `maximum` and `default` values, and therefore these values are wiped during `to_glyphs` conversion. Normally, `to_designspace` recalculates these values using the sources and the axis' mapping values. However if there are no mappings in the axis, `to_designspace` will error.

This error can be avoided by adding identity mappings to the designspace, as `to_glyphs` will keep these mappings, which then provides `to_designspace` with the required mappings it needs to calculate the minimum and maximum values of the custom axis. However, during runtime `to_designspace` deletes all identity mappings, thus causing the roundtrip to fail.

The fix is to make `to_glyphs` create an identity mapping if one is needed (when the are no axis mappings provided in the designspace) using the axis' minimum and maximum values, so that this information is not lost. This identity mapping can then be used to recalculate the min, max values on the next `to_designspace` trip (which still deletes the identity mappings). Thus allowing roundtrips to not lose information.

Summary:
* `to_glyphs` now stores axis min, max information as identity mappings to stop the loss of this information which previously caused errors during roundtrip.